### PR TITLE
Update dependencies and run ci checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -392,15 +392,15 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -429,6 +429,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Boyd Johnson <johnson.boyd@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-geo = "^0.31"
-geojson = "^0.24"
-num-traits = "^0.2"
-rstar = "^0.12"
-serde_json = "^1"
+geo = "0.30.0"
+geojson = "0.24.2"
+num-traits = "0.2.19"
+rstar = "0.12.2"
+serde_json = "1.0.145"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Boyd Johnson <johnson.boyd@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-geo = "0.30.0"
-geojson = "0.24.2"
-num-traits = "0.2.19"
-rstar = "0.12.2"
-serde_json = "1.0.145"
+geo = "^0.31"
+geojson = "^0.24"
+num-traits = "^0.2"
+rstar = "^0.12"
+serde_json = "^1"

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -16,8 +16,7 @@
 use geo::{Coord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use geojson::{Geometry, LineStringType, PointType, PolygonType, Value};
 use num_traits::Float;
-use std::fmt::Debug;
-use std::iter::FromIterator;
+use std::{fmt::Debug, iter::FromIterator};
 
 pub fn create_point_type<T>(point: &Point<T>) -> PointType
 where

--- a/src/linestring_feature.rs
+++ b/src/linestring_feature.rs
@@ -20,8 +20,7 @@ use crate::{
     generic::{GenericFeature, GetBbox},
     json::JsonObject,
 };
-use geo::algorithm::Euclidean;
-use geo::algorithm::{bounding_rect::BoundingRect, Length};
+use geo::algorithm::{bounding_rect::BoundingRect, Euclidean, Length};
 use geojson::{feature::Id, Bbox, LineStringType};
 use num_traits::identities::Zero;
 use rstar::{Envelope, Point, PointDistance, RTreeObject, AABB};

--- a/tests/test_geometry_collection_feature.rs
+++ b/tests/test_geometry_collection_feature.rs
@@ -55,8 +55,8 @@ fn test_try_into_geometry_collection_success_and_bbox() {
             .expect("GeometryCollectionFeature conversion should succeed");
 
         // The expected bbox spans from the line's start to the polygon's max
-        assert_eq!(gc_feature.geo_geometry().0.is_empty(), false);
-        assert_eq!(gc_feature.geometries().len() > 0, true);
+        assert!(!gc_feature.geo_geometry().0.is_empty());
+        assert!(!gc_feature.geometries().is_empty());
     } else {
         panic!("The geojson did not parse as a Feature");
     }


### PR DESCRIPTION
Update all Rust dependencies to their latest versions and resolve new Clippy warnings.

The update to `geo 0.31.0` required using a nightly Rust toolchain due to its `edition2024` feature. Dependency notations in `Cargo.toml` were reverted to caret requirements to maintain consistency, and new Clippy warnings were addressed.

---
<a href="https://cursor.com/background-agent?bcId=bc-987d2001-45f2-4630-9629-1957347e9e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-987d2001-45f2-4630-9629-1957347e9e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

