### PR TITLE
[codex] update geojson dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.9",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +49,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -55,12 +82,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools",
  "num-traits",
 ]
 
@@ -78,67 +104,104 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "float_next_after"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "geo"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcutr",
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "i_overlay",
  "log",
  "num-traits",
+ "rand",
+ "rand_pcg",
  "robust",
- "rstar",
+ "rstar 0.12.2",
+ "sif-itree",
  "spade",
 ]
 
 [[package]]
 name = "geo-types"
-version = "0.7.17"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a4dcd69d35b2c87a7c83bce9af69fd65c9d68d3833a0ded568983928f3fc99"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
  "rayon",
- "rstar",
+ "rstar 0.10.0",
+ "rstar 0.11.0",
+ "rstar 0.12.2",
+ "rstar 0.8.4",
+ "rstar 0.9.3",
  "serde",
+ "spade",
 ]
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "geojson"
-version = "0.24.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
+checksum = "510c094bfc76ea34d02eee00833254945b70491d79a9c0b050abed6eaa799ffb"
 dependencies = [
  "geo-types",
  "log",
  "serde",
  "serde_json",
  "thiserror",
+ "tinyvec",
 ]
 
 [[package]]
@@ -148,8 +211,26 @@ dependencies = [
  "geo",
  "geojson",
  "num-traits",
- "rstar",
+ "rstar 0.12.2",
  "serde_json",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -163,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -174,34 +255,62 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.9",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_overlay"
-version = "4.0.6"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcccbd4e4274e0f80697f5fbc6540fdac533cce02f2081b328e68629cce24f9"
+checksum = "934cba666ad1bf60436a190af6eaa3f58f57b5bad28268ce3fb45d9185862232"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -212,51 +321,51 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
  "i_float",
 ]
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-traits"
@@ -269,28 +378,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.101"
+name = "pdqselect"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -314,20 +453,85 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rstar"
-version = "0.12.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
 dependencies = [
- "heapless",
+ "heapless 0.6.1",
  "num-traits",
+ "pdqselect",
+ "serde",
  "smallvec",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "rstar"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless 0.8.0",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -361,16 +565,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "smallvec"
@@ -380,9 +590,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spade"
-version = "2.15.0"
+version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
 dependencies = [
  "hashbrown",
  "num-traits",
@@ -391,16 +601,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
+name = "spin"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -409,18 +628,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -428,7 +647,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.19"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "serde_core",
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Boyd Johnson <johnson.boyd@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-geo = "^0.31"
-geojson = "^0.24"
+geo = "^0.33"
+geojson = "^1"
 num-traits = "^0.2"
 rstar = "^0.12"
 serde_json = "^1"

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use geo::{Coord, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
-use geojson::{Geometry, LineStringType, PointType, PolygonType, Value};
+use geojson::{Geometry, GeometryValue, LineStringType, PointType, PolygonType};
 use num_traits::Float;
 use std::fmt::Debug;
 use std::iter::FromIterator;
@@ -26,7 +26,7 @@ where
     let x: f64 = point.x().to_f64().unwrap();
     let y: f64 = point.y().to_f64().unwrap();
 
-    vec![x, y]
+    vec![x, y].into()
 }
 
 pub fn create_line_string_type<T>(line_string: &LineString<T>) -> LineStringType
@@ -176,16 +176,24 @@ where
     T: Float + Debug,
 {
     geo::GeometryCollection::from_iter(geometries.iter().map(|g| match &g.value {
-        Value::Point(p) => geo::Geometry::Point(create_geo_point(p)),
-        Value::LineString(l) => geo::Geometry::LineString(create_geo_line_string(l)),
-        Value::Polygon(p) => geo::Geometry::Polygon(create_geo_polygon(p)),
-        Value::MultiPoint(p) => geo::Geometry::MultiPoint(create_geo_multi_point(p)),
-        Value::MultiPolygon(p) => geo::Geometry::MultiPolygon(create_geo_multi_polygon(p)),
-        Value::MultiLineString(p) => {
-            geo::Geometry::MultiLineString(create_geo_multi_line_string(p))
+        GeometryValue::Point { coordinates } => geo::Geometry::Point(create_geo_point(coordinates)),
+        GeometryValue::LineString { coordinates } => {
+            geo::Geometry::LineString(create_geo_line_string(coordinates))
         }
-        Value::GeometryCollection(g) => {
-            geo::Geometry::GeometryCollection(create_geo_geometry_collection(g))
+        GeometryValue::Polygon { coordinates } => {
+            geo::Geometry::Polygon(create_geo_polygon(coordinates))
+        }
+        GeometryValue::MultiPoint { coordinates } => {
+            geo::Geometry::MultiPoint(create_geo_multi_point(coordinates))
+        }
+        GeometryValue::MultiPolygon { coordinates } => {
+            geo::Geometry::MultiPolygon(create_geo_multi_polygon(coordinates))
+        }
+        GeometryValue::MultiLineString { coordinates } => {
+            geo::Geometry::MultiLineString(create_geo_multi_line_string(coordinates))
+        }
+        GeometryValue::GeometryCollection { geometries } => {
+            geo::Geometry::GeometryCollection(create_geo_geometry_collection(geometries))
         }
     }))
 }

--- a/src/geometry_collection.rs
+++ b/src/geometry_collection.rs
@@ -18,7 +18,7 @@ use crate::{
     MultiPointFeature, MultiPolygonFeature, PointFeature, PolygonFeature,
 };
 use geo::{algorithm::bounding_rect::BoundingRect, Coord, Rect};
-use geojson::{feature::Id, Bbox, Geometry, Value};
+use geojson::{feature::Id, Bbox, Geometry, GeometryValue};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -42,7 +42,9 @@ impl GeometryCollectionFeature {
 
 impl From<GeometryCollectionFeature> for geojson::Feature {
     fn from(val: GeometryCollectionFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::GeometryCollection(val.geometries));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::GeometryCollection {
+            geometries: val.geometries,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -66,7 +68,7 @@ impl GenericFeature<GeometryCollectionFeature, Vec<Geometry>> for GeometryCollec
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<Vec<Geometry>, GeoJsonConversionError> {
-        if let geojson::Value::GeometryCollection(geometry_collection) = feature
+        if let geojson::GeometryValue::GeometryCollection { geometries } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -75,7 +77,7 @@ impl GenericFeature<GeometryCollectionFeature, Vec<Geometry>> for GeometryCollec
             })?
             .value
         {
-            Ok(geometry_collection)
+            Ok(geometries)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find GeometryCollection feature".to_string(),
@@ -89,14 +91,26 @@ impl GenericFeature<GeometryCollectionFeature, Vec<Geometry>> for GeometryCollec
     ) -> Result<(), GeoJsonConversionError> {
         for geom in geometry {
             match &geom.value {
-                Value::Point(p) => PointFeature::check_geometry(p, feature)?,
-                Value::LineString(l) => LineStringFeature::check_geometry(l, feature)?,
-                Value::Polygon(p) => PolygonFeature::check_geometry(p, feature)?,
-                Value::MultiPoint(p) => MultiPointFeature::check_geometry(p, feature)?,
-                Value::MultiLineString(l) => MultiLineStringFeature::check_geometry(l, feature)?,
-                Value::MultiPolygon(p) => MultiPolygonFeature::check_geometry(p, feature)?,
-                Value::GeometryCollection(g) => {
-                    GeometryCollectionFeature::check_geometry(g, feature)?
+                GeometryValue::Point { coordinates } => {
+                    PointFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::LineString { coordinates } => {
+                    LineStringFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::Polygon { coordinates } => {
+                    PolygonFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::MultiPoint { coordinates } => {
+                    MultiPointFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::MultiLineString { coordinates } => {
+                    MultiLineStringFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::MultiPolygon { coordinates } => {
+                    MultiPolygonFeature::check_geometry(coordinates, feature)?
+                }
+                GeometryValue::GeometryCollection { geometries } => {
+                    GeometryCollectionFeature::check_geometry(geometries, feature)?
                 }
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,23 +92,25 @@ impl TryFrom<geojson::Feature> for Feature {
 
     fn try_from(feature: geojson::Feature) -> Result<Feature, Self::Error> {
         match feature.geometry.as_ref().map(|g| &g.value) {
-            Some(geojson::Value::Point(_)) => PointFeature::try_from(feature).map(Feature::Point),
-            Some(geojson::Value::LineString(_)) => {
+            Some(geojson::GeometryValue::Point { .. }) => {
+                PointFeature::try_from(feature).map(Feature::Point)
+            }
+            Some(geojson::GeometryValue::LineString { .. }) => {
                 LineStringFeature::try_from(feature).map(Feature::LineString)
             }
-            Some(geojson::Value::Polygon(_)) => {
+            Some(geojson::GeometryValue::Polygon { .. }) => {
                 PolygonFeature::try_from(feature).map(Feature::Polygon)
             }
-            Some(geojson::Value::MultiPoint(_)) => {
+            Some(geojson::GeometryValue::MultiPoint { .. }) => {
                 MultiPointFeature::try_from(feature).map(Feature::MultiPoint)
             }
-            Some(geojson::Value::MultiLineString(_)) => {
+            Some(geojson::GeometryValue::MultiLineString { .. }) => {
                 MultiLineStringFeature::try_from(feature).map(Feature::MultiLineString)
             }
-            Some(geojson::Value::MultiPolygon(_)) => {
+            Some(geojson::GeometryValue::MultiPolygon { .. }) => {
                 MultiPolygonFeature::try_from(feature).map(Feature::MultiPolygon)
             }
-            Some(geojson::Value::GeometryCollection(_)) => {
+            Some(geojson::GeometryValue::GeometryCollection { .. }) => {
                 GeometryCollectionFeature::try_from(feature).map(Feature::GeometryCollection)
             }
             None => Err(GeoJsonConversionError::MissingGeometry(feature.id)),

--- a/src/linestring_feature.rs
+++ b/src/linestring_feature.rs
@@ -48,7 +48,9 @@ impl LineStringFeature {
 
 impl From<LineStringFeature> for geojson::Feature {
     fn from(val: LineStringFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::LineString(val.line));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::LineString {
+            coordinates: val.line,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -72,7 +74,7 @@ impl GenericFeature<LineStringFeature, LineStringType> for LineStringFeature {
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<LineStringType, GeoJsonConversionError> {
-        if let geojson::Value::LineString(linestring_type) = feature
+        if let geojson::GeometryValue::LineString { coordinates } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -81,7 +83,7 @@ impl GenericFeature<LineStringFeature, LineStringType> for LineStringFeature {
             })?
             .value
         {
-            Ok(linestring_type)
+            Ok(coordinates)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find Linestring feature".into(),

--- a/src/multilinestring_feature.rs
+++ b/src/multilinestring_feature.rs
@@ -49,7 +49,9 @@ impl MultiLineStringFeature {
 
 impl From<MultiLineStringFeature> for geojson::Feature {
     fn from(val: MultiLineStringFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::MultiLineString(val.lines));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::MultiLineString {
+            coordinates: val.lines,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -75,7 +77,7 @@ impl GenericFeature<MultiLineStringFeature, Vec<LineStringType>> for MultiLineSt
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<Vec<LineStringType>, GeoJsonConversionError> {
-        if let geojson::Value::MultiLineString(lines) = feature
+        if let geojson::GeometryValue::MultiLineString { coordinates } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -84,7 +86,7 @@ impl GenericFeature<MultiLineStringFeature, Vec<LineStringType>> for MultiLineSt
             })?
             .value
         {
-            Ok(lines)
+            Ok(coordinates)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find a MultiLinestring Feature".into(),

--- a/src/multipoint_feature.rs
+++ b/src/multipoint_feature.rs
@@ -49,7 +49,9 @@ impl MultiPointFeature {
 
 impl From<MultiPointFeature> for geojson::Feature {
     fn from(val: MultiPointFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::MultiPoint(val.points));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::MultiPoint {
+            coordinates: val.points,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -73,7 +75,7 @@ impl GenericFeature<MultiPointFeature, Vec<PointType>> for MultiPointFeature {
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<Vec<PointType>, GeoJsonConversionError> {
-        if let geojson::Value::MultiPoint(points) = feature
+        if let geojson::GeometryValue::MultiPoint { coordinates } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -82,7 +84,7 @@ impl GenericFeature<MultiPointFeature, Vec<PointType>> for MultiPointFeature {
             })?
             .value
         {
-            Ok(points)
+            Ok(coordinates)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find a MultiPoint feature".into(),

--- a/src/multipolygon_feature.rs
+++ b/src/multipolygon_feature.rs
@@ -49,7 +49,9 @@ impl MultiPolygonFeature {
 
 impl From<MultiPolygonFeature> for geojson::Feature {
     fn from(val: MultiPolygonFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::MultiPolygon(val.polygons));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::MultiPolygon {
+            coordinates: val.polygons,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -83,8 +85,8 @@ impl GenericFeature<MultiPolygonFeature, Vec<PolygonType>> for MultiPolygonFeatu
             .value;
 
         match value {
-            geojson::Value::MultiPolygon(polygons) => Ok(polygons),
-            geojson::Value::Polygon(polygon) => Ok(vec![polygon]),
+            geojson::GeometryValue::MultiPolygon { coordinates } => Ok(coordinates),
+            geojson::GeometryValue::Polygon { coordinates } => Ok(vec![coordinates]),
             _ => Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find a MultiPolygon feature".into(),
             )),

--- a/src/point_feature.rs
+++ b/src/point_feature.rs
@@ -46,7 +46,9 @@ impl PointFeature {
 
 impl From<PointFeature> for geojson::Feature {
     fn from(val: PointFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::Point(val.point));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::Point {
+            coordinates: val.point,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -70,7 +72,7 @@ impl GenericFeature<PointFeature, PointType> for PointFeature {
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<PointType, GeoJsonConversionError> {
-        if let geojson::Value::Point(point_type) = feature
+        if let geojson::GeometryValue::Point { coordinates } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -79,7 +81,7 @@ impl GenericFeature<PointFeature, PointType> for PointFeature {
             })?
             .value
         {
-            Ok(point_type)
+            Ok(coordinates)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find Point feature".into(),

--- a/src/polygon_feature.rs
+++ b/src/polygon_feature.rs
@@ -50,7 +50,9 @@ impl PolygonFeature {
 
 impl From<PolygonFeature> for geojson::Feature {
     fn from(val: PolygonFeature) -> Self {
-        let geometry = geojson::Geometry::new(geojson::Value::Polygon(val.polygon));
+        let geometry = geojson::Geometry::new(geojson::GeometryValue::Polygon {
+            coordinates: val.polygon,
+        });
 
         geojson::Feature {
             id: val.id,
@@ -74,7 +76,7 @@ impl GenericFeature<PolygonFeature, PolygonType> for PolygonFeature {
     fn take_geometry_type(
         feature: &mut geojson::Feature,
     ) -> Result<PolygonType, GeoJsonConversionError> {
-        if let geojson::Value::Polygon(polygon) = feature
+        if let geojson::GeometryValue::Polygon { coordinates } = feature
             .geometry
             .take()
             .ok_or_else(|| {
@@ -83,7 +85,7 @@ impl GenericFeature<PolygonFeature, PolygonType> for PolygonFeature {
             })?
             .value
         {
-            Ok(polygon)
+            Ok(coordinates)
         } else {
             Err(GeoJsonConversionError::IncorrectGeometryValue(
                 "Error: did not find Polygon feature".into(),


### PR DESCRIPTION
## Summary

This PR updates the Rust geospatial dependency stack and migrates the library to the current `geojson` 1.0 API.

The user-facing effect is that `geojson-rstar` now builds against `geo` 0.33 and `geojson` 1.0 instead of staying on the older 0.31/0.24 line. The main source change is the `geojson` 1.0 geometry representation: `geojson::Value` is now `geojson::GeometryValue`, geometry enum variants use named fields, and `Position` is now a dedicated type rather than a plain `Vec<f64>`.

## Dependency Review

I scanned updates with `cargo update --dry-run --verbose`, checked for open Dependabot PRs, queried crates.io publication dates for the one-day cooldown, and reviewed unpacked Cargo registry source diffs for the updated crates.

The reviewed changes did not show suspicious provenance changes, new binary artifacts, unexpected network access, credential access, filesystem traversal, or native/FFI additions. Existing build scripts remain in established low-level crates such as `proc-macro2`, `quote`, `serde_json`, `thiserror`, and `libm`; their diffs are limited to compiler-probe or target-configuration changes.

## Implementation

- Bumped `geo` to `^0.33`.
- Bumped `geojson` to `^1`.
- Regenerated `Cargo.lock`.
- Replaced deprecated `geojson::Value` usage with `geojson::GeometryValue`.
- Updated pattern matching and construction for named `coordinates` / `geometries` fields.
- Converted generated `PointType` values into the new `Position` type with `.into()`.

## Validation

- `cargo fmt --check`
- `cargo test`

`cargo test` is the CI command from `cloudbuild-check.yaml`.
