### PR TITLE
[codex] update i_overlay dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "i_overlay"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cba666ad1bf60436a190af6eaa3f58f57b5bad28268ce3fb45d9185862232"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
  "i_float",
  "i_key_sort",


### PR DESCRIPTION
## Issue

`cargo update --dry-run --verbose` on the current `origin/master` reported one remaining lockfile-compatible dependency update: `i_overlay` from 4.5.1 to 4.5.2. `i_overlay` is pulled transitively by `geo 0.33.1`, which this crate uses directly.

## Review

I reviewed the crates.io source archive diff for `i_overlay` 4.5.1 -> 4.5.2 before updating. The published 4.5.2 crate was older than the required 1-day cooldown at review time. The only production source change is in `src/mesh/outline/builder.rs`, where collinear offset joins now fall back to a dot-product check instead of relying on a non-zero cross product debug assertion. The existing non-Cargo `src/segm/build.rs` file is unchanged, the `unsafe` occurrence count is unchanged, and I did not find new network access, process spawning, credential access, native artifacts, or dependency expansion in the crate package used by this build.

The crate changelog packaged with 4.5.2 does not document the 4.x patch releases, so the source diff was the authoritative review source.

## Fix

Updated `Cargo.lock` to `i_overlay 4.5.2`. There are no code migrations required because this crate does not use `i_overlay` directly.

## Validation

- `cargo update --dry-run --verbose`
- `cargo tree --locked -i i_overlay@4.5.1`
- `cargo test`
- `cargo fmt --check`
