### PR TITLE
[codex] Update either to 1.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"


### PR DESCRIPTION
## Summary

Updates the lockfile-resolved `either` crate from 1.15.0 to 1.16.0. This is a transitive dependency through `rayon`, which is pulled in by `geo-types`, `i_key_sort`, and `i_overlay`.

## Dependency review

`cargo update --dry-run --verbose` reported two compatible updates: `either` 1.15.0 to 1.16.0 and `serde_json` 1.0.149 to 1.0.150. `serde_json` 1.0.150 was published at 2026-05-21T20:26:09Z, which was less than the required 1-day cooldown at review time, so it was intentionally skipped.

For `either` 1.16.0, I compared the packaged 1.15.0 and 1.16.0 crate sources from the Cargo registry cache. The diff adds side-specific convenience APIs, exposes `map_both!`, extends `for_both!`, adds `#[track_caller]` to public panicking methods, and updates docs, CI metadata, package metadata, and the crate's own lockfile. I found no new build script, binary artifacts, vendored/generated/minified code, native bindings, unexpected network/process/credential/filesystem traversal behavior, or suspicious unsafe changes.

## Validation

Ran the CI source-of-truth command from `cloudbuild-check.yaml`:

```sh
cargo test
```

All tests passed.
