### PR TITLE
[codex] update rust lockfile dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "byteorder"
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
## Issue

The scheduled dependency scan found lockfile-compatible Rust dependency updates for `geojson-rstar`.

Open Dependabot PRs in `localo-com/geojson-rstar` are stale:

- #23 bumps `serde_json` from 1.0.145 to 1.0.149; this PR moves the lockfile to 1.0.150.
- #21 bumps `geo` from 0.31.0 to 0.32.0; the current manifest allows `^0.33` and the lockfile is already on 0.33.1.

## Cause and effect

The lockfile was still pinned to older patch/minor-compatible transitive releases:

- `autocfg` 1.5.0
- `either` 1.15.0
- `log` 0.4.29
- `serde_json` 1.0.149

Keeping these behind means the crate misses upstream fixes and small API/parser improvements in transitive dependencies, while the manifest already permits these versions.

## Source review

I compared the packaged `.crate` contents for each current and target version before updating:

- `autocfg` 1.5.0 -> 1.5.1: test wrapper refactor only; no runtime code changes.
- `either` 1.15.0 -> 1.16.0: added convenience APIs/macros and `#[track_caller]` on panicking methods; no suspicious file or dependency changes.
- `log` 0.4.29 -> 0.4.30: adds `ToValue`/`Value` support for `std::net` address types and bumps MSRV to 1.71; no build script, native artifacts, or network/process behavior added.
- `serde_json` 1.0.149 -> 1.0.150: hardens object enum key parsing to reject non-string keys, bumps MSRV to 1.71, and adds a regression test. Existing `build.rs` is unchanged.

No new binary artifacts, vendored/generated/minified code, unexpected filesystem/network/credential access, dependency explosion, typosquatting-like replacements, or provenance changes were found.

## Fix

Updated `Cargo.lock` to the reviewed compatible versions.

## Validation

- `cargo update --dry-run --verbose`
- `cargo outdated`
- `gh pr list --author app/dependabot --state open --json number,title,headRefName,baseRefName,url,createdAt,updatedAt`
- `cargo tree -i autocfg@1.5.0`
- `cargo tree -i either@1.15.0`
- `cargo tree -i log@0.4.29`
- `cargo tree -i serde_json@1.0.149`
- `cargo test`
- final `cargo update --dry-run --verbose`
