### PR TITLE
[codex] Update log dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
Updates the lockfile-compatible transitive log dependency from 0.4.29 to 0.4.30 on top of latest origin/master. This is pulled in through geo and geojson; Cargo reports log 0.4.31 as latest, but it was published on 2026-06-02T12:07:16Z and is still inside the required one-day cooldown at this run time, so this PR intentionally targets the audited older release.\n\nSource audit: compared the published crates.io package contents for log 0.4.29 and 0.4.30 from the Cargo registry cache. The diff contains version/checksum metadata, changelog updates, CI workflow pinning, MSRV increase to Rust 1.71, docs root URL updates, and a small source change adding ToValue support for std::net address types under the std feature. No new build.rs, binary/native artifacts, vendored/minified code, unexpected network/process/credential behavior, dependency explosion, or provenance concerns were found.\n\nNo code migration is required in this crate because log is transitive only and the public API change is additive.\n\nValidation run: cargo update --dry-run, cargo outdated, cargo tree -i log, cargo fmt --check, and cargo test.