### PR TITLE
[codex] Update log dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## Summary

Updates the transitive `log` crate in `Cargo.lock` from `0.4.30` to `0.4.31`.

`cargo update --dry-run` now sees `log 0.4.32`, but that version was published on 2026-06-04 at 07:44 UTC and is inside the one-day dependency cooldown, so this PR intentionally targets the eligible `0.4.31` release instead.

## Dependency Audit

`log` is pulled in transitively by `geo` and `geojson`. The published crates.io archive diff from `0.4.30` to `0.4.31` was small: structured logging keys now preserve static strings where possible, the docs root and changelog were updated, and a few compile-error typos were fixed. There were no added or removed files, no build script, no new binary or native artifacts, no vendored or minified code, no unexpected network/process/credential/filesystem behavior, and no dependency explosion.

The release notes describe the same structured logging key improvement: "Leverage static str key when possible".

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo update --dry-run`
- `cargo outdated`
- `cargo tree -i log`
- `gh pr list --repo localo-com/geojson-rstar --author app/dependabot --state open --json number,title,headRefName,baseRefName,url`
