### PR TITLE
[codex] update log to 0.4.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## Summary

Updates the transitive Rust logging facade dependency in Cargo.lock from log 0.4.30 to 0.4.32. The crate is pulled in by geo and geojson; no manifest change or application code migration is required.

## Dependency audit

- Ran cargo update --dry-run and cargo outdated on the latest origin/master.
- Checked open Dependabot PRs with gh; none were open.
- Verified log 0.4.32 was published at 2026-06-04T07:44:19Z, older than the one-day cooldown at scan time.
- Compared the published crates.io archives log 0.4.30 and log 0.4.32 under /tmp/geojson-rstar-log-audit-20260605.
- Source changes are limited to structured logging key/value support, static key handling, std string conversion support, changelog/docs/tests, and package metadata.
- No added build.rs, binary/native artifacts, vendored/minified code, new unsafe locations, network/process/credential behavior, dependency explosion, or provenance concern found.

## Validation

- cargo test
- cargo fmt --check (passes with existing stable-rustfmt merge_imports warnings)
- cargo update --dry-run
- cargo outdated