### PR TITLE
[codex] Update log dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## Summary

Updates the transitive Rust dependency `log` from 0.4.30 to 0.4.32 in `Cargo.lock`. The dependency is pulled in by `geo` and `geojson`; this crate does not use it directly.

## Dependency audit

- Ran `cargo update --dry-run` and `cargo outdated`; the only lockfile-compatible update was `log 0.4.30 -> 0.4.32`.
- Checked open Dependabot PRs with `gh pr list --author app/dependabot --state open`; none were open.
- Verified `log 0.4.32` was published on 2026-06-04T07:44:19Z, outside the one-day cooldown.
- Compared unpacked published `.crate` archives for 0.4.30 and 0.4.32 under `/tmp/geojson-rstar-log-audit-20260608`.
- Source diff is limited to structured logging key handling, `Value` string conversion feature gating, changelog/docs/tests, and package metadata.
- No new `build.rs`, binary/native artifacts, vendored/minified code, new unsafe blocks, network/process/credential behavior, filesystem traversal, dependency explosion, or provenance concerns found.

## Migration

No code migration required; this is a patch-level transitive dependency update.

## Validation

- `cargo test`
- `cargo fmt --check` (passes with existing stable-rustfmt `merge_imports` warnings)
- `cargo update --dry-run` after update reports 0 remaining compatible updates
- `cargo outdated` after update only reports upstream constrained/removed transitive rows