### PR TITLE
[codex] update rust dependency lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -595,9 +595,9 @@ checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spade"


### PR DESCRIPTION
## Summary

Updates lockfile-compatible Rust dependencies after auditing the published crate source archives:

- `memchr` 2.8.1 -> 2.8.2
- `smallvec` 1.15.1 -> 1.15.2

Both versions are older than the 1-day dependency cooldown. No code migration was required because these are transitive patch updates.

## Audit Notes

- Compared unpacked `.crate` archives for current and target versions under `/tmp/geojson-rstar-deps-audit-20260615`.
- No new `build.rs`, binary/native artifacts, vendored/minified code, unexpected network/process/credential behavior, dependency explosion, or provenance concerns were found.
- `memchr` fixes undefined behavior in lower-level packed-pair APIs and removes unnecessary clones in `into_owned` implementations.
- `smallvec` fixes `DrainFilter::keep_rest` for zero inline capacity, adds a rustc 1.93 `MaybeUninit` codegen workaround, and excludes development-only files from the published package.

## Validation

- `cargo test`
- `cargo fmt --check` (passes with existing stable-rustfmt warnings about `merge_imports`)
- `cargo update --dry-run`
- `cargo outdated`
- `gh pr list --repo localo-com/geojson-rstar --author app/dependabot --state open --json number,title,headRefName,baseRefName,url,updatedAt`