### PR TITLE
[codex] update rust dependency lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -595,9 +595,9 @@ checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spade"
@@ -628,9 +628,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Updates lockfile-compatible Rust dependencies on current origin/master:

- memchr 2.8.1 -> 2.8.2
- smallvec 1.15.1 -> 1.15.2
- syn 2.0.117 -> 2.0.118

No Cargo.toml or source-code migrations were required because all updates are transitive patch releases.

## Audit

- Verified target crate publish times in Cargo sparse registry metadata; all targets are older than the 1-day cooldown and not yanked.
- Compared old and new published .crate contents from the Cargo registry cache.
- memchr: source changes fix UB in lower-level packed-pair APIs and remove unnecessary clones in into_owned; no new build.rs, binary artifacts, vendored/minified code, unexpected network/process/filesystem behavior, or dependency explosion.
- smallvec: fixes DrainFilter::keep_rest for zero-capacity SmallVec, adds documented MaybeUninit codegen workaround for rustc 1.93, and narrows cargo packaging via include list. This introduces documented internal unsafe expressions for the MaybeUninit workaround; no build script, native/binary artifacts, network/process behavior, or dependency explosion were added.
- syn: documentation and parser/test maintenance changes; no new build.rs, native/binary artifacts, network/process behavior, or dependency explosion affecting this project.

## Validation

- cargo test
- cargo fmt --check (passes with existing stable-rustfmt merge_imports warnings)
- cargo update --dry-run
- cargo outdated
