### PR TITLE
[codex] Update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -595,9 +595,9 @@ checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spade"
@@ -628,9 +628,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Updates the Cargo lockfile to the latest compatible Rust dependencies found by Cargo:

| crate | current | target | dependency type | semver level | result |
|---|---:|---:|---|---|---|
| memchr | 2.8.1 | 2.8.2 | transitive via serde_json | patch | upgraded |
| smallvec | 1.15.1 | 1.15.2 | transitive via rstar/spade | patch | upgraded |
| syn | 2.0.117 | 2.0.118 | transitive proc-macro dependency | patch | upgraded |
| earcut | 0.4.5 | 0.4.10 | transitive via geo | patch | skipped: geo pins `earcut = "=0.4.5"` |
| pdqselect | 0.1.0 | 0.1.1 | transitive via geo-types/rstar 0.8.4 | patch | skipped: rstar 0.8.4 pins `pdqselect = "=0.1.0"` |

No direct manifest dependency is behind the latest crates.io release: `geo 0.33.1`, `geojson 1.0.0`, `rstar 0.13.0`, `num-traits 0.2.19`, and `serde_json 1.0.150` are current. There are no open Dependabot PRs.

## Dependency review

- `memchr 2.8.2`: published 2026-06-12, outside the 1-day cooldown. Reviewed static `.crate` archive diff from 2.8.1 to 2.8.2. Changes fix undefined behavior in lower-level public packed-pair APIs, remove unnecessary clones in `into_owned`, and update version metadata. No new `build.rs`, binary artifacts, network/process/filesystem access, FFI, or added unsafe blocks in the diff. Upstream has tags but no GitHub release entry; reviewed tag compare `2.8.1...2.8.2`.
- `smallvec 1.15.2`: published 2026-06-11, outside the 1-day cooldown. Reviewed static `.crate` archive diff from 1.15.1 to 1.15.2 and upstream release notes. Changes exclude development scripts/tests/benches from the published package, fix `DrainFilter::keep_rest` for zero inline capacity, and work around a rustc 1.93 `MaybeUninit` performance regression. Explicit callout: the diff adds two documented `unsafe { MaybeUninit::uninit().assume_init() }` uses for the workaround; no build script, binary artifact, FFI, network/process/filesystem access, or dependency explosion was added.
- `syn 2.0.118`: published 2026-06-16, outside the 1-day cooldown. Reviewed static `.crate` archive diff from 2.0.117 to 2.0.118 and upstream release notes. Changes are documentation, clippy/lint cleanup, rustdoc flag correction, and internal test-suite updates. No new `build.rs`, binary artifacts, network/process/filesystem access in runtime code, FFI, or added unsafe blocks in the diff.

## Migration and risk

No code migration was required. All upgrades are compatible transitive patch updates and do not change this crate's public API usage. Breaking-change risk is low.

## Validation

- `cargo update --dry-run --verbose`
- `cargo update`
- `cargo update -p earcut --precise 0.4.10 --dry-run --verbose` (confirmed upstream exact pin blocker)
- `cargo update -p pdqselect --precise 0.1.1 --dry-run --verbose` (confirmed upstream exact pin blocker)
- `cargo test`
- final `cargo update --dry-run --verbose` (0 compatible updates remaining; only exact-pinned `earcut` and `pdqselect` remain unchanged)
