### PR TITLE
Update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## Summary

- Updated the compatible Rust lockfile dependency `log` from `0.4.32` to `0.4.33`.
- Left direct manifest dependencies unchanged; `cargo outdated --root-deps-only` reports they are up to date.
- Skipped `quote 1.0.46` because it is inside the required 1-day cooldown window.

## Dependency Review

### log 0.4.32 -> 0.4.33

- Type: transitive dependency via `geo` and `geojson`.
- Semver level: patch.
- Source diff: compared cached crates.io `.crate` archives for `0.4.32` and `0.4.33`. Published file set is unchanged; no `build.rs`, executable files, binary artifacts, native bindings, process/network/filesystem access, or new unsafe surface were added. Existing unsafe entries are unchanged.
- Changelog: upstream changelog says this release fixes key comparison (`rust-lang/log#732`). The code diff replaces derived equality/order/hash for `MaybeStaticStr` with value-based implementations and adds key equality tests.
- Published: `2026-06-20T22:08:55Z`, outside the 1-day cooldown for this run.
- Breaking-change risk: low; patch-only transitive logging facade fix.
- Migration: none.
- Result: upgraded.

### quote 1.0.45 -> 1.0.46

- Type: transitive dependency via proc-macro dependencies (`serde_derive`, `syn`, `thiserror-impl`).
- Semver level: patch.
- Published: `2026-06-22T04:57:07Z`, inside the 1-day cooldown window when checked at `2026-06-22T10:06:30Z`.
- Result: skipped due to cooldown.

### earcut 0.4.5 -> 0.4.10

- Type: transitive dependency via `geo`.
- Semver level: patch.
- Blocker: `geo 0.33.1` requires `earcut = "=0.4.5"`; `cargo update -p earcut --precise 0.4.10 --dry-run` fails dependency resolution.
- Result: skipped due to upstream exact pin.

### pdqselect 0.1.0 -> 0.1.1

- Type: transitive dependency through `geo-types` optional old `rstar 0.8.4` lockfile entry.
- Semver level: patch.
- Blocker: `rstar 0.8.4` requires `pdqselect = "=0.1.0"`; `cargo update -p pdqselect --precise 0.1.1 --dry-run` fails dependency resolution.
- Result: skipped due to upstream exact pin.

## Validation

- `cargo update --dry-run --verbose`
- `cargo outdated`
- `cargo outdated --root-deps-only`
- `cargo tree -i log@0.4.33`
- `cargo tree -i quote@1.0.46`
- `.crate` archive diff for `log 0.4.32 -> 0.4.33`
- `cargo test`